### PR TITLE
fix incorrect zone id with no zone change

### DIFF
--- a/Source/Triggernometry/RealPlugin.cs
+++ b/Source/Triggernometry/RealPlugin.cs
@@ -3273,6 +3273,7 @@ namespace Triggernometry
         public void ZoneChangeDelegate(uint ZoneID, string ZoneName)
         {
             PluginBridges.BridgeFFXIV.ZoneID = ZoneID;
+            ZoneChanged(currentZone);
         }
 
         public void NetworkLogLineReceiver(uint sequence, int messagetype, string message)


### PR DESCRIPTION
**Problem**: When starting ACT, Triggernometry instantly checks triggers zone restrictions, but zone id is still equal to 0, because events are set after and a zone change has yet to happen.
A zone change event is fired after setting up events, but the trigger restrictions are not refreshed. This means that triggers using ZoneId will not work until an actual in-game zone change happens. Login does not count as a zone change if the zone is the same as when you logged out.

**Fix**: This change is fixing all the aforementioned issues. However **it is not ideal** in the sense that both this and
https://github.com/paissaheavyindustries/Triggernometry/blob/master/Source/Triggernometry/RealPlugin.cs#L3236 will call `ZoneChange`.
It is not that bad, as it only happens on zone change, but I am mentioning it, as you may have a better fix in mind.

**Note**: I tried using `GetCurrentTerritoryID` to manually fetch the zone id before Triggernometry checks restrictions, but that just returns 0, probably because ACT is not ready fast enough.