### PR TITLE
Add null check for _TestInput when manually firing a trigger.

### DIFF
--- a/Source/Triggernometry/CustomControls/UserInterface.cs
+++ b/Source/Triggernometry/CustomControls/UserInterface.cs
@@ -2008,7 +2008,7 @@ namespace Triggernometry.CustomControls
 
         private void ForceFireTrigger(Trigger t)
         {
-            if (t._TestInput == "")
+            if (!(t._TestInput?.Length > 0))
             {
                 Context ctx = new Context();
                 ctx.plug = plug;


### PR DESCRIPTION
This fixes an bug where an exception would be thrown for old triggers.
In the current implementation, manually firing a trigger will only work after editing and resaving it.