### PR TITLE
Fix constants initialization, add OBSWebsocketPassword constant

### DIFF
--- a/Source/Triggernometry/Forms/ActionForm.cs
+++ b/Source/Triggernometry/Forms/ActionForm.cs
@@ -364,6 +364,8 @@ namespace Triggernometry.Forms
                 expDiscordUrl.Expression = "";
                 cbxDiscordTts.Checked = false;
                 cbxObsOpType.SelectedIndex = 0;
+                expObsEndpoint.Expression = "ws://${_const[OBSWebsocketEndpoint]}:${_const[OBSWebsocketPort]}";
+                expObsPassword.Expression = "${_const[OBSWebsocketPassword]}";
                 expObsSceneName.Expression = "";
                 expObsSourceName.Expression = "";
                 expObsJSONPayload.Expression = "";

--- a/Source/Triggernometry/Forms/ConfigurationForm.cs
+++ b/Source/Triggernometry/Forms/ConfigurationForm.cs
@@ -899,7 +899,7 @@ namespace Triggernometry.Forms
             consts["OBSWebsocketPassword"] = new VariableScalar() { Value = "" };
             if (constants != null)
             {
-                foreach (KeyValuePair<string, VariableScalar> kp in plug.cfg.Constants)
+                foreach (KeyValuePair<string, VariableScalar> kp in constants)
                 {
                     consts[kp.Key] = new VariableScalar() { Value = kp.Value.Value, LastChanged = kp.Value.LastChanged, LastChanger = kp.Value.LastChanger };
                 }

--- a/Source/Triggernometry/Forms/ConfigurationForm.cs
+++ b/Source/Triggernometry/Forms/ConfigurationForm.cs
@@ -82,7 +82,7 @@ namespace Triggernometry.Forms
                 cbxAutosaveConfig.Checked = false;
                 nudAutosaveMinutes.Value = 5;
                 SecuritySettingsFromConfiguration(null);
-                SetupDefaultConsts();
+                SetupConsts(null);
             }
             else
             {
@@ -119,11 +119,7 @@ namespace Triggernometry.Forms
                 a.TemplateTrigger.CopySettingsTo(template);
                 SetupJobOrder(a);
                 SecuritySettingsFromConfiguration(a);
-                foreach (KeyValuePair<string, VariableScalar> kp in plug.cfg.Constants)
-                {
-                    consts[kp.Key] = new VariableScalar() { Value = kp.Value.Value, LastChanged = kp.Value.LastChanged, LastChanger = kp.Value.LastChanger };
-                }
-                RefreshConsts();
+                SetupConsts(plug.cfg.Constants);
             }
             if (a.StartupTriggerType == Configuration.StartupTriggerTypeEnum.Trigger)
             {
@@ -894,13 +890,20 @@ namespace Triggernometry.Forms
             return null;
         }
 
-        private void SetupDefaultConsts()
+        private void SetupConsts(SerializableDictionary<string, VariableScalar> constants)
         {
             consts["TelestoEndpoint"] = new VariableScalar() { Value = "localhost" };
             consts["TelestoPort"] = new VariableScalar() { Value = "51323" };
             consts["OBSWebsocketEndpoint"] = new VariableScalar() { Value = "localhost" };
             consts["OBSWebsocketPort"] = new VariableScalar() { Value = "4455" };
             consts["OBSWebsocketPassword"] = new VariableScalar() { Value = "" };
+            if (constants != null)
+            {
+                foreach (KeyValuePair<string, VariableScalar> kp in plug.cfg.Constants)
+                {
+                    consts[kp.Key] = new VariableScalar() { Value = kp.Value.Value, LastChanged = kp.Value.LastChanged, LastChanger = kp.Value.LastChanger };
+                }
+            }
             RefreshConsts();
         }
 

--- a/Source/Triggernometry/Forms/ConfigurationForm.cs
+++ b/Source/Triggernometry/Forms/ConfigurationForm.cs
@@ -82,6 +82,7 @@ namespace Triggernometry.Forms
                 cbxAutosaveConfig.Checked = false;
                 nudAutosaveMinutes.Value = 5;
                 SecuritySettingsFromConfiguration(null);
+                SetupDefaultConsts();
             }
             else
             {
@@ -891,6 +892,16 @@ namespace Triggernometry.Forms
                 }
             }
             return null;
+        }
+
+        private void SetupDefaultConsts()
+        {
+            consts["TelestoEndpoint"] = new VariableScalar() { Value = "localhost" };
+            consts["TelestoPort"] = new VariableScalar() { Value = "51323" };
+            consts["OBSWebsocketEndpoint"] = new VariableScalar() { Value = "localhost" };
+            consts["OBSWebsocketPort"] = new VariableScalar() { Value = "4455" };
+            consts["OBSWebsocketPassword"] = new VariableScalar() { Value = "" };
+            RefreshConsts();
         }
 
         private void RefreshConsts()

--- a/Source/Triggernometry/RealPlugin.cs
+++ b/Source/Triggernometry/RealPlugin.cs
@@ -2033,12 +2033,13 @@ namespace Triggernometry
                     cfg.FfxivPartyOrdering = Configuration.FfxivPartyOrderingEnum.CustomSelfFirst;
                 }
             }
-            if (v < new Version("1.1.6.6"))
+            if (v < new Version("1.1.6.8"))
             {
                 cfg.Constants["TelestoEndpoint"] = new VariableScalar() { Value = "localhost" };
                 cfg.Constants["TelestoPort"] = new VariableScalar() { Value = "51323" };
                 cfg.Constants["OBSWebsocketEndpoint"] = new VariableScalar() { Value = "localhost" };
                 cfg.Constants["OBSWebsocketPort"] = new VariableScalar() { Value = "4455" };
+                cfg.Constants["OBSWebsocketPassword"] = new VariableScalar() { Value = "" };
             }
             cfg.Constants["TriggernometryVersionMajor"] = new VariableScalar() { Value = v.Major.ToString() };
             cfg.Constants["TriggernometryVersionMinor"] = new VariableScalar() { Value = v.Minor.ToString() };

--- a/Source/Triggernometry/RealPlugin.cs
+++ b/Source/Triggernometry/RealPlugin.cs
@@ -2033,14 +2033,6 @@ namespace Triggernometry
                     cfg.FfxivPartyOrdering = Configuration.FfxivPartyOrderingEnum.CustomSelfFirst;
                 }
             }
-            if (v < new Version("1.1.6.8"))
-            {
-                cfg.Constants["TelestoEndpoint"] = new VariableScalar() { Value = "localhost" };
-                cfg.Constants["TelestoPort"] = new VariableScalar() { Value = "51323" };
-                cfg.Constants["OBSWebsocketEndpoint"] = new VariableScalar() { Value = "localhost" };
-                cfg.Constants["OBSWebsocketPort"] = new VariableScalar() { Value = "4455" };
-                cfg.Constants["OBSWebsocketPassword"] = new VariableScalar() { Value = "" };
-            }
             cfg.Constants["TriggernometryVersionMajor"] = new VariableScalar() { Value = v.Major.ToString() };
             cfg.Constants["TriggernometryVersionMinor"] = new VariableScalar() { Value = v.Minor.ToString() };
             cfg.Constants["TriggernometryVersionBuild"] = new VariableScalar() { Value = v.Build.ToString() };


### PR DESCRIPTION
This fixes the following issues:
- Users with a fresh config (new users or users resetting their config due to corruption) will not have Telesto/OBS constants initialized.
- Users who did _not_ try the 1.1.6.5e beta and updated manually will not have Telesto/OBS constants initialized. 

This PR also adds:
- OBSWebsocketPassword constant.
- Set the default Endpoint/Password on OBS actions to use the OBS constants