### PR TITLE
Fix Log Message event not sending ZoneName when "Process message as log line" is checked 

### DIFF
--- a/Source/Triggernometry/Action.cs
+++ b/Source/Triggernometry/Action.cs
@@ -1838,7 +1838,7 @@ namespace Triggernometry
                         {
                             if (_LogProcess == true)
                             {
-                                ctx.plug.LogLineQueuer(ctx.EvaluateStringExpression(ActionContextLogger, ctx, _LogMessageText), "", _LogMessageTarget);
+                                ctx.plug.LogLineQueuer(ctx.EvaluateStringExpression(ActionContextLogger, ctx, _LogMessageText), ctx.EvaluateStringExpression(ActionContextLogger, ctx, ctx.plug.currentZone), _LogMessageTarget);
                             }
                             else
                             {


### PR DESCRIPTION
Test trigger:
```
<?xml version="1.0"?>
<TriggernometryExport Version="1">
  <ExportedFolder Id="927a8e25-0c01-429b-b4a1-a8f86fb4d6fe" ZoneFilterRegularExpression="^Shirogane$" Name="ZoneTest" Enabled="true">
    <Folders>
      <Folder ZoneFilterEnabled="True" Id="d26c542b-1046-4b93-a6e7-fc9d44c6efd5" ZoneFilterRegularExpression="^Shirogane$" Name="Name" Enabled="true">
        <Folders />
        <Triggers>
          <Trigger Enabled="true" Source="FFXIVNetwork" Sequential="True" Name="!test" Id="dd2e0e61-0f24-45d2-99c3-33beacb24af1" RegularExpression="^00\|[^|]*\|0038\|\|!test">
            <Actions>
              <Action OrderNumber="1" SystemBeepFreqExpression="800" OBSEndPoint="" TextAuraFontSize="8.25" TextAuraFontName="Microsoft Sans Serif" ActionType="SystemBeep">
                <Condition Enabled="false" Grouping="Or" />
              </Action>
              <Action OrderNumber="2" LogMessageTarget="NetworkFFXIV" LogMessageText="THISISATEST" LogProcess="True" OBSEndPoint="ws://${_const[OBSWebsocketEndpoint]}:${_const[OBSWebsocketPort]}" OBSPassword="${_const[OBSWebsocketPassword]}" TextAuraFontSize="8.25" TextAuraFontName="Microsoft Sans Serif" ActionType="LogMessage">
                <Condition Enabled="false" Grouping="Or" />
              </Action>
            </Actions>
            <Condition Enabled="false" Grouping="Or" />
          </Trigger>
          <Trigger Enabled="true" Source="FFXIVNetwork" Sequential="True" Name="THISISATEST" Id="298e7894-d0e5-4469-a9d5-036f353985b8" RegularExpression="THISISATEST">
            <Actions>
              <Action OrderNumber="1" SystemBeepFreqExpression="400" SystemBeepLengthExpression="200" OBSEndPoint="" TextAuraFontSize="8.25" TextAuraFontName="Microsoft Sans Serif" ActionType="SystemBeep" ExecutionDelayExpression="200">
                <Condition Enabled="false" Grouping="Or" />
              </Action>
            </Actions>
            <Condition Enabled="false" Grouping="Or" />
          </Trigger>
        </Triggers>
      </Folder>
      <Folder FFXIVZoneFilterEnabled="True" FfxivZoneFilterRegularExpression="^641$" Id="0d187c97-ead7-4bd6-91de-b8b151299949" Name="ID" Enabled="true">
        <Folders />
        <Triggers>
          <Trigger Enabled="true" Source="FFXIVNetwork" Sequential="True" Name="!test" Id="3e7ebfd2-99a6-4986-8ee6-1fa5e4e47998" RegularExpression="^00\|[^|]*\|0038\|\|!test">
            <Actions>
              <Action OrderNumber="1" SystemBeepFreqExpression="800" OBSEndPoint="" TextAuraFontSize="8.25" TextAuraFontName="Microsoft Sans Serif" ActionType="SystemBeep">
                <Condition Enabled="false" Grouping="Or" />
              </Action>
              <Action OrderNumber="2" LogMessageTarget="NetworkFFXIV" LogMessageText="THISISATEST" LogProcess="True" OBSEndPoint="ws://${_const[OBSWebsocketEndpoint]}:${_const[OBSWebsocketPort]}" OBSPassword="${_const[OBSWebsocketPassword]}" TextAuraFontSize="8.25" TextAuraFontName="Microsoft Sans Serif" ActionType="LogMessage">
                <Condition Enabled="false" Grouping="Or" />
              </Action>
            </Actions>
            <Condition Enabled="false" Grouping="Or" />
          </Trigger>
          <Trigger Enabled="true" Source="FFXIVNetwork" Sequential="True" Name="THISISATEST" Id="81a7ea15-e638-419d-8afd-1491035ffc29" RegularExpression="THISISATEST">
            <Actions>
              <Action OrderNumber="1" SystemBeepFreqExpression="400" SystemBeepLengthExpression="200" OBSEndPoint="" TextAuraFontSize="8.25" TextAuraFontName="Microsoft Sans Serif" ActionType="SystemBeep" ExecutionDelayExpression="200">
                <Condition Enabled="false" Grouping="Or" />
              </Action>
            </Actions>
            <Condition Enabled="false" Grouping="Or" />
          </Trigger>
        </Triggers>
      </Folder>
    </Folders>
    <Triggers />
  </ExportedFolder>
</TriggernometryExport>
```