### PR TITLE
Fix outdated exec script translation

### DIFF
--- a/Translations/zh-CN.triglations.xml
+++ b/Translations/zh-CN.triglations.xml
@@ -577,7 +577,7 @@
         <TranslationEntry Key="internal/Action/descdiscordttsmsg" Translation="发送TTS消息 ({0}) 到Discord 聊天室 ({1})" />
         <TranslationEntry Key="internal/Action/descenablefolder" Translation="启用分组 ({0})" />
         <TranslationEntry Key="internal/Action/descendencounter" Translation="结束战斗" />
-        <TranslationEntry Key="internal/Action/descexecscript" Translation="执行 ({0}) 脚本" />
+        <TranslationEntry Key="internal/Action/descexecscript" Translation="执行 C# 脚本" />
         <TranslationEntry Key="internal/Action/descfilereadcsvtable" Translation="将 CSV 文件 ({0}) 读入表格变量 ({1})" />
         <TranslationEntry Key="internal/Action/descfilereadcsvtablecache" Translation="将 CSV 文件 ({0}) 读入表格变量 ({1})，并缓存至硬盘" />
         <TranslationEntry Key="internal/Action/descfilereadlistvar" Translation="将文件 ({0}) 内容读入列表变量 ({1})" />


### PR DESCRIPTION
It will cause error when using exec script action (look like it also affected other language, but I don't know how this string was translated in other languages, so I can't change it accordingly)
Related code:
https://github.com/paissaheavyindustries/Triggernometry/blob/6de49d67d31249b267c05175b8d64cb1617443c4/Source/Triggernometry/Action.cs#L565-L567
https://github.com/paissaheavyindustries/Triggernometry/blob/6a87dc8d0c5bdb6d0115060b93646f50c5f2dbd5/Source/Triggernometry/I18n.cs#L74-L91