### PR TITLE
Add "true" modulo numeric function

### DIFF
--- a/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
+++ b/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
@@ -21,7 +21,7 @@ namespace Triggernometry.CustomControls
             // numeric
             "pi", "pi2", "pi05", "pi025", "pi0125", "pitorad", "piofrad", "phi", "major", "minor",
             "abs(x)", "cos(x)", "cosh(x)", "arccos(x)", "cosec(x)", "sin(x)", "sinh(x)", "arcsin(x)", "sec(x)", "tan(x)", "tanh(x)", "arctan(x)", "arctan2(x, y)",
-            "cotan(x)", "distance(x1, y1, x2, y2)", "radtodeg(x)", "degtorad(x)", "max(...)", "min(...)", "random(x, y)", "sqrt(x)", "root(x, y)", "rem(x, y)",
+            "cotan(x)", "distance(x1, y1, x2, y2)", "radtodeg(x)", "degtorad(x)", "max(...)", "min(...)", "random(x, y)", "sqrt(x)", "root(x, y)", "rem(x, y)", "mod(x, y)",
             "pow(x, y)", "exp(x)", "log(x)", "log(x, y)", "round(x)", "round(x, y)", "floor(x)", "ceiling(x)", "sign(x)", "hex2dec(x)", "or(...)", "and(...)", "if(x,y,z)",
             // expressions
             "numeric", "string", "var", "evar", "lvar", "elvar", "tvar", "tvarcl", "tvarrl", "etvar", "func", "pvar", "epvar", "plvar", "eplvar", "ptvar", "ptvarcl", "ptvarrl", "eptvar",

--- a/Source/Triggernometry/MathParser.cs
+++ b/Source/Triggernometry/MathParser.cs
@@ -98,7 +98,7 @@ namespace Triggernometry
         /// to the parser. Please note that you are able to change that using
         /// boolean flags
         /// </summary>
-        /// <param name="loadPreDefinedFunctions">This will load "abs", "cos", "cosh", "arccos", "sin", "sinh", "arcsin", "tan", "tanh", "arctan", "sqrt", "rem", "round"</param>
+        /// <param name="loadPreDefinedFunctions">This will load "abs", "cos", "cosh", "arccos", "sin", "sinh", "arcsin", "tan", "tanh", "arctan", "sqrt", "rem", "mod", "round"</param>
         /// <param name="loadPreDefinedOperators">This will load "%", "*", ":", "/", "+", "-", ">", "&lt;", "="</param>
         /// <param name="loadPreDefinedVariables">This will load "pi", "pi2", "pi05", "pi025", "pi0125", "pitograd", "piofgrad", "e", "phi", "major", "minor"</param>
         public MathParser(bool loadPreDefinedFunctions = true, bool loadPreDefinedOperators = true, bool loadPreDefinedVariables = true)
@@ -182,6 +182,7 @@ namespace Triggernometry
 
                 LocalFunctions.Add("sqrt", x => Math.Sqrt(x[0]));
                 LocalFunctions.Add("rem", x => Math.IEEERemainder(x[0], x[1]));
+                LocalFunctions.Add("mod", x => (x[0] % x[1] + x[1]) % x[1]);
                 LocalFunctions.Add("root", x => Math.Pow(x[0], 1.0 / x[1]));
 
                 LocalFunctions.Add("pow", x => Math.Pow(x[0], x[1]));


### PR DESCRIPTION
The `%` operator in C# acts as a remainder function rather than a true modulo function. This PR adds a `mod(x, y)` function to perform these operations.

[The Wiki](https://github.com/paissaheavyindustries/Triggernometry/wiki/Triggernometry-FAQ-and-examples#mathematical-functions) will need to be updated as well.