### PR TITLE
Remove default OBS and textaura settings from export

### DIFF
--- a/Source/Triggernometry/ActionProps.cs
+++ b/Source/Triggernometry/ActionProps.cs
@@ -2334,7 +2334,7 @@ namespace Triggernometry
         {
             get
             {
-                if (_TextAuraFontSize == 10.0f || ActionType != Action.ActionTypeEnum.TextAura)
+                if (ActionType != ActionTypeEnum.TextAura)
                 {
                     return null;
                 }
@@ -2670,7 +2670,7 @@ namespace Triggernometry
         {
             get
             {
-                if (_TextAuraFontName == "" || ActionType != Action.ActionTypeEnum.TextAura)
+                if (_TextAuraFontName == "" || ActionType != ActionTypeEnum.TextAura)
                 {
                     return null;
                 }

--- a/Source/Triggernometry/ActionProps.cs
+++ b/Source/Triggernometry/ActionProps.cs
@@ -1630,13 +1630,13 @@ namespace Triggernometry
             }
         }
 
-        internal string _OBSEndPoint = @"ws://127.0.0.1:4444";
+        internal string _OBSEndPoint = @"ws://${_const[OBSWebsocketEndpoint]}:${_const[OBSWebsocketPort]}";
         [XmlAttribute]
         public string OBSEndPoint
         {
             get
             {
-                if (_OBSEndPoint == @"ws://127.0.0.1:4444")
+                if (_OBSEndPoint == @"ws://${_const[OBSWebsocketEndpoint]}:${_const[OBSWebsocketPort]}")
                 {
                     return null;
                 }
@@ -1648,13 +1648,13 @@ namespace Triggernometry
             }
         }
 
-        internal string _OBSPassword = "";
+        internal string _OBSPassword = @"${_const[OBSWebsocketPassword]}";
         [XmlAttribute]
         public string OBSPassword
         {
             get
             {
-                if (_OBSPassword == "")
+                if (_OBSPassword == @"${_const[OBSWebsocketPassword]}")
                 {
                     return null;
                 }
@@ -2298,13 +2298,13 @@ namespace Triggernometry
         {
             get
             {
-                if (_TextAuraFontSize != 10.0f)
+                if (_TextAuraFontSize == 10.0f || ActionType != Action.ActionTypeEnum.TextAura)
                 {
-                    return I18n.ThingToString(_TextAuraFontSize);
+                    return null;
                 }
                 else
                 {
-                    return null;
+                    return I18n.ThingToString(_TextAuraFontSize);
                 }
             }
             set
@@ -2634,7 +2634,7 @@ namespace Triggernometry
         {
             get
             {
-                if (_TextAuraFontName == "")
+                if (_TextAuraFontName == "" || ActionType != Action.ActionTypeEnum.TextAura)
                 {
                     return null;
                 }


### PR DESCRIPTION
Resolves #88. Should also help reduce the size of an export.
For TextAuraFontX, I figured it would be best to always include it since the default settings can vary based on the users system settings; however, the export result will only include it for TextAura actions