### PR TITLE
Add LiveSplit Action Type

### DIFF
--- a/Source/Triggernometry/ActionProps.cs
+++ b/Source/Triggernometry/ActionProps.cs
@@ -32,6 +32,7 @@ namespace Triggernometry
             LogMessage,
             ListVariable,
             ObsControl,
+            LiveSplitControl,
             GenericJson,
             WindowMessage,
             DiskFile,
@@ -174,6 +175,19 @@ namespace Triggernometry
             ShowSource,
             HideSource,
             JSONPayload
+        }
+
+        public enum LiveSplitControlTypeEnum
+        {
+            StartOrSplit,
+            Start,
+            Split,
+            UndoSplit,
+            SkipSplit,
+            Reset,
+            Pause,
+            Resume,
+            CustomPayload
         }
 
         public enum KeypressTypeEnum
@@ -1756,6 +1770,45 @@ namespace Triggernometry
             }
         }
 
+        #endregion
+        #region Action specific properties - LiveSplit
+        internal LiveSplitControlTypeEnum _LSControlType { get; set; } = LiveSplitControlTypeEnum.StartOrSplit;
+        [XmlAttribute]
+        public string LiveSplitControlType
+        {
+            get
+            {
+                if (_LSControlType != LiveSplitControlTypeEnum.StartOrSplit)
+                {
+                    return _LSControlType.ToString();
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            set
+            {
+                _LSControlType = (LiveSplitControlTypeEnum)Enum.Parse(typeof(LiveSplitControlTypeEnum), value);
+            }
+        }
+        internal string _LSCustomPayload = "";
+        [XmlAttribute]
+        public string LiveSplitCustomPayload
+        {
+            get
+            {
+                if (_LSControlType != LiveSplitControlTypeEnum.CustomPayload)
+                {
+                    return null;
+                }
+                return _LSCustomPayload;
+            }
+            set
+            {
+                _LSCustomPayload = value;
+            }
+        }
         #endregion
         #region Action specific properties - Placeholder
         #endregion

--- a/Source/Triggernometry/Forms/ActionForm.Designer.cs
+++ b/Source/Triggernometry/Forms/ActionForm.Designer.cs
@@ -261,6 +261,12 @@
             this.expObsSceneName = new Triggernometry.CustomControls.ExpressionTextBox();
             this.lblObsWebsocketInfo = new System.Windows.Forms.Label();
             this.txtObsWebsocketLink = new System.Windows.Forms.TextBox();
+            this.tabLiveSplitControl = new System.Windows.Forms.TabPage();
+            this.tableLayoutPanelLs = new System.Windows.Forms.TableLayoutPanel();
+            this.lblLsCustPayload = new System.Windows.Forms.Label();
+            this.expLSCustPayload = new Triggernometry.CustomControls.ExpressionTextBox();
+            this.cbxLsOpType = new System.Windows.Forms.ComboBox();
+            this.lblLsOpType = new System.Windows.Forms.Label();
             this.tabGenericJson = new System.Windows.Forms.TabPage();
             this.jsonTableLayout = new System.Windows.Forms.TableLayoutPanel();
             this.prsJsonVariable = new Triggernometry.CustomControls.PersistenceSwitch();
@@ -441,6 +447,8 @@
             this.tableLayoutPanel17.SuspendLayout();
             this.tabObsControl.SuspendLayout();
             this.tableLayoutPanel18.SuspendLayout();
+            this.tabLiveSplitControl.SuspendLayout();
+            this.tableLayoutPanelLs.SuspendLayout();
             this.tabGenericJson.SuspendLayout();
             this.jsonTableLayout.SuspendLayout();
             this.tabWindowMessage.SuspendLayout();
@@ -533,6 +541,7 @@
             "Log message",
             "List variable operation",
             "OBS remote control operation",
+            "LiveSplit remote control operation",
             "Generic JSON operation",
             "Send window message",
             "File operation",
@@ -590,6 +599,7 @@
             this.tbcActionSettings.Controls.Add(this.tabLogMessage);
             this.tbcActionSettings.Controls.Add(this.tabListVariable);
             this.tbcActionSettings.Controls.Add(this.tabObsControl);
+            this.tbcActionSettings.Controls.Add(this.tabLiveSplitControl);
             this.tbcActionSettings.Controls.Add(this.tabGenericJson);
             this.tbcActionSettings.Controls.Add(this.tabWindowMessage);
             this.tbcActionSettings.Controls.Add(this.tabFile);
@@ -3801,6 +3811,97 @@
             this.txtObsWebsocketLink.Text = "https://obsproject.com/forum/resources/obs-websocket-remote-control-of-obs-studio" +
     "-made-easy.466/";
             // 
+            // tabLiveSplitControl
+            // 
+            this.tabLiveSplitControl.Controls.Add(this.tableLayoutPanelLs);
+            this.tabLiveSplitControl.Location = new System.Drawing.Point(4, 25);
+            this.tabLiveSplitControl.Name = "tabLiveSplitControl";
+            this.tabLiveSplitControl.Size = new System.Drawing.Size(742, 414);
+            this.tabLiveSplitControl.TabIndex = 27;
+            this.tabLiveSplitControl.Text = "LiveSplit";
+            this.tabLiveSplitControl.UseVisualStyleBackColor = true;
+            // 
+            // tableLayoutPanelLs
+            // 
+            this.tableLayoutPanelLs.AutoSize = true;
+            this.tableLayoutPanelLs.ColumnCount = 3;
+            this.tableLayoutPanelLs.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelLs.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelLs.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanelLs.Controls.Add(this.lblLsCustPayload, 0, 3);
+            this.tableLayoutPanelLs.Controls.Add(this.expLSCustPayload, 1, 3);
+            this.tableLayoutPanelLs.Controls.Add(this.cbxLsOpType, 1, 0);
+            this.tableLayoutPanelLs.Controls.Add(this.lblLsOpType, 0, 0);
+            this.tableLayoutPanelLs.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanelLs.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanelLs.Name = "tableLayoutPanelLs";
+            this.tableLayoutPanelLs.RowCount = 4;
+            this.tableLayoutPanelLs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLs.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLs.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanelLs.Size = new System.Drawing.Size(742, 53);
+            this.tableLayoutPanelLs.TabIndex = 4;
+            // 
+            // lblLsCustPayload
+            // 
+            this.lblLsCustPayload.AutoSize = true;
+            this.lblLsCustPayload.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblLsCustPayload.Location = new System.Drawing.Point(3, 27);
+            this.lblLsCustPayload.Name = "lblLsCustPayload";
+            this.lblLsCustPayload.Size = new System.Drawing.Size(82, 26);
+            this.lblLsCustPayload.TabIndex = 26;
+            this.lblLsCustPayload.Text = "Custom payload";
+            this.lblLsCustPayload.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // expLSCustPayload
+            // 
+            this.expLSCustPayload.AutocompleteAvailable = true;
+            this.expLSCustPayload.AutoSize = true;
+            this.tableLayoutPanelLs.SetColumnSpan(this.expLSCustPayload, 2);
+            this.expLSCustPayload.Dock = System.Windows.Forms.DockStyle.Top;
+            this.expLSCustPayload.Expression = "";
+            this.expLSCustPayload.ExpressionType = Triggernometry.CustomControls.ExpressionTextBox.SupportedExpressionTypeEnum.String;
+            this.expLSCustPayload.Location = new System.Drawing.Point(91, 30);
+            this.expLSCustPayload.Name = "expLSCustPayload";
+            this.expLSCustPayload.ReadOnly = false;
+            this.expLSCustPayload.Size = new System.Drawing.Size(648, 20);
+            this.expLSCustPayload.TabIndex = 25;
+            // 
+            // cbxLsOpType
+            // 
+            this.tableLayoutPanelLs.SetColumnSpan(this.cbxLsOpType, 2);
+            this.cbxLsOpType.Dock = System.Windows.Forms.DockStyle.Top;
+            this.cbxLsOpType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbxLsOpType.FormattingEnabled = true;
+            this.cbxLsOpType.Items.AddRange(new object[] {
+            "Start run or split",
+            "Start run",
+            "Split",
+            "Undo split",
+            "Skip split",
+            "Reset run",
+            "Pause run",
+            "Resume run",
+            "Custom payload"});
+            this.cbxLsOpType.Location = new System.Drawing.Point(91, 3);
+            this.cbxLsOpType.Name = "cbxLsOpType";
+            this.cbxLsOpType.Size = new System.Drawing.Size(648, 21);
+            this.cbxLsOpType.TabIndex = 22;
+            this.cbxLsOpType.SelectedIndexChanged += new System.EventHandler(this.cbxLsOpType_SelectedIndexChanged);
+            // 
+            // lblLsOpType
+            // 
+            this.lblLsOpType.AutoSize = true;
+            this.lblLsOpType.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblLsOpType.Location = new System.Drawing.Point(3, 0);
+            this.lblLsOpType.Name = "lblLsOpType";
+            this.lblLsOpType.Size = new System.Drawing.Size(82, 27);
+            this.lblLsOpType.TabIndex = 18;
+            this.lblLsOpType.Text = "Operation type";
+            this.lblLsOpType.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // tabGenericJson
             // 
             this.tabGenericJson.Controls.Add(this.jsonTableLayout);
@@ -5756,6 +5857,10 @@
             this.tabObsControl.PerformLayout();
             this.tableLayoutPanel18.ResumeLayout(false);
             this.tableLayoutPanel18.PerformLayout();
+            this.tabLiveSplitControl.ResumeLayout(false);
+            this.tabLiveSplitControl.PerformLayout();
+            this.tableLayoutPanelLs.ResumeLayout(false);
+            this.tableLayoutPanelLs.PerformLayout();
             this.tabGenericJson.ResumeLayout(false);
             this.tabGenericJson.PerformLayout();
             this.jsonTableLayout.ResumeLayout(false);
@@ -6197,5 +6302,11 @@
         private CustomControls.ExpressionTextBox expLoopIncr;
         private CustomControls.ExpressionTextBox expLoopInit;
         private System.Windows.Forms.Label lblLoopIncr;
+        private System.Windows.Forms.TabPage tabLiveSplitControl;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelLs;
+        private System.Windows.Forms.Label lblLsCustPayload;
+        private CustomControls.ExpressionTextBox expLSCustPayload;
+        private System.Windows.Forms.ComboBox cbxLsOpType;
+        private System.Windows.Forms.Label lblLsOpType;
     }
 }

--- a/Source/Triggernometry/Forms/ActionForm.cs
+++ b/Source/Triggernometry/Forms/ActionForm.cs
@@ -369,6 +369,8 @@ namespace Triggernometry.Forms
                 expObsSceneName.Expression = "";
                 expObsSourceName.Expression = "";
                 expObsJSONPayload.Expression = "";
+                cbxLsOpType.SelectedIndex = 0;
+                expLSCustPayload.Expression = "";
                 cbxTextAuraOp.SelectedIndex = 0;
                 cbxTextAuraAlignment.SelectedIndex = 4;
                 expTextAuraName.Expression = "";
@@ -575,6 +577,8 @@ namespace Triggernometry.Forms
                 expObsSceneName.Expression = a._OBSSceneName;
                 expObsSourceName.Expression = a._OBSSourceName;
                 expObsJSONPayload.Expression = a._OBSJSONPayload;
+                cbxLsOpType.SelectedIndex = (int)a._LSControlType;
+                expLSCustPayload.Expression = a._LSCustomPayload;
                 cbxTextAuraOp.SelectedIndex = (int)a._TextAuraOp;
                 cbxJsonType.SelectedIndex = (int)a._JsonOperationType;
                 expJsonEndpoint.Expression = a._JsonEndpointExpression;
@@ -862,6 +866,8 @@ namespace Triggernometry.Forms
             a._OBSSceneName = expObsSceneName.Expression;
             a._OBSSourceName = expObsSourceName.Expression;
             a._OBSJSONPayload = expObsJSONPayload.Expression;
+            a._LSControlType = (Action.LiveSplitControlTypeEnum)cbxLsOpType.SelectedIndex;
+            a._LSCustomPayload = expLSCustPayload.Expression;
             a._JsonOperationType = (Action.HTTPMethodEnum)cbxJsonType.SelectedIndex;
             a._JsonEndpointExpression = expJsonEndpoint.Expression;
             a._JsonFiringExpression = expJsonFiring.Expression;
@@ -1912,6 +1918,12 @@ namespace Triggernometry.Forms
             expObsSceneName.Enabled = (cbxObsOpType.SelectedIndex >= 15 && cbxObsOpType.SelectedIndex <= 17);
             expObsSourceName.Enabled = (cbxObsOpType.SelectedIndex >= 16 && cbxObsOpType.SelectedIndex <= 17);
             expObsJSONPayload.Enabled = (cbxObsOpType.SelectedIndex >= 18);
+        }
+
+        private void cbxLsOpType_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            expLSCustPayload.Enabled = (cbxLsOpType.SelectedIndex == cbxLsOpType.Items.Count - 1);
+            lblLsCustPayload.Enabled = expLSCustPayload.Enabled;
         }
 
         private void cbxKeypressMethod_SelectedIndexChanged(object sender, EventArgs e)

--- a/Source/Triggernometry/LiveSplitController.cs
+++ b/Source/Triggernometry/LiveSplitController.cs
@@ -43,6 +43,7 @@ namespace Triggernometry
                 {
                     if (IsConnected == true)
                         return;
+                    Dispose();
                     client = new NamedPipeClientStream(".", "LiveSplit", PipeDirection.Out, PipeOptions.Asynchronous);
                     client.Connect(3000);
                     clientWriter = new StreamWriter(client);

--- a/Source/Triggernometry/LiveSplitController.cs
+++ b/Source/Triggernometry/LiveSplitController.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.IO;
+using System.IO.Pipes;
+
+namespace Triggernometry
+{
+
+    internal class LiveSplitController : IDisposable
+    {
+
+        internal bool IsConnected
+        {
+            get
+            {
+                lock (lockobj)
+                {
+                    if (client == null || clientWriter?.BaseStream == null)
+                        return false;
+                    return client.IsConnected;
+                }
+            }
+        }
+
+        private NamedPipeClientStream client;
+        private StreamWriter clientWriter;
+        private object lockobj = new object();
+
+        internal LiveSplitController() { }
+
+        public void Dispose()
+        {
+            clientWriter?.Dispose();
+            client?.Dispose();
+            clientWriter = null;
+            client = null;
+        }
+
+        internal void Connect()
+        {
+            lock (lockobj)
+            {
+                try
+                {
+                    if (IsConnected == true)
+                        return;
+                    client = new NamedPipeClientStream(".", "LiveSplit", PipeDirection.Out, PipeOptions.Asynchronous);
+                    client.Connect(3000);
+                    clientWriter = new StreamWriter(client);
+                    clientWriter.AutoFlush = true;
+                }
+                catch (Exception)
+                {
+                    Dispose();
+                    throw;
+                }
+            }
+        }
+
+        internal void SendCommand(string command)
+        {
+            try
+            {
+                clientWriter.WriteLine(command);
+            }
+            catch (Exception)
+            {
+                Dispose();
+                throw;
+            }
+        }
+
+        internal void StartOrSplit()
+        {
+            SendCommand("startorsplit");
+        }
+
+        internal void Start()
+        {
+            SendCommand("start");
+        }
+
+        internal void Split()
+        {
+            SendCommand("split");
+        }
+
+        internal void UndoSplit()
+        {
+            SendCommand("undosplit");
+        }
+
+        internal void SkipSplit()
+        {
+            SendCommand("skipsplit");
+        }
+
+        internal void Reset()
+        {
+            SendCommand("reset");
+        }
+
+        internal void Pause()
+        {
+            SendCommand("pause");
+        }
+
+        internal void Resume()
+        {
+            SendCommand("resume");
+        }
+    }
+}

--- a/Source/Triggernometry/RealPlugin.cs
+++ b/Source/Triggernometry/RealPlugin.cs
@@ -532,6 +532,7 @@ namespace Triggernometry
         internal Dictionary<string, Forms.AuraContainerForm> textauras;
         internal bool DisableLogging;
         internal ObsController _obs = null;
+        internal LiveSplitController _livesplit = null;
         internal CancellationTokenSource cts = null;
         internal object ctslock = new object();
         public Form mainform { get; set; }
@@ -2186,6 +2187,7 @@ namespace Triggernometry
                 AuraUpdateThread.Name = "AuraUpdateThread";
                 AuraUpdateThread.Start();
                 _obs = new ObsController();
+                _livesplit = new LiveSplitController();
                 exwhere = I18n.Translate("internal/Plugin/iniscripting", "setting up scripting - try changing the plugin load order in ACT");
                 scripting = new Interpreter(this);
                 pluginStatusText.Text = I18n.Translate("internal/Plugin/iniready", "Ready");
@@ -2800,6 +2802,11 @@ namespace Triggernometry
             {
                 _obs.Dispose();
                 _obs = null;
+            }
+            if (_livesplit != null)
+            {
+                _livesplit.Dispose();
+                _livesplit = null;
             }
             if (ExitEvent != null)
             {

--- a/Source/Triggernometry/TriggernometryPlugin.csproj
+++ b/Source/Triggernometry/TriggernometryPlugin.csproj
@@ -311,6 +311,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="ObsController.cs" />
+    <Compile Include="LiveSplitController.cs" />
     <Compile Include="Parser.cs" />
     <Compile Include="Scarborough\OverrideHelper.cs" />
     <Compile Include="PluginBridges\BridgeFFXIV.cs" />

--- a/Translations/default.triglations.xml
+++ b/Translations/default.triglations.xml
@@ -26,6 +26,7 @@
     <TranslationEntry Key="ActionForm/cbxActionType[Log message]" Translation="Log message" />
     <TranslationEntry Key="ActionForm/cbxActionType[Mutex operation]" Translation="Mutex operation" />
     <TranslationEntry Key="ActionForm/cbxActionType[OBS remote control operation]" Translation="OBS remote control operation" />
+    <TranslationEntry Key="ActionForm/cbxActionType[LiveSplit remote control operation]" Translation="LiveSplit remote control operation" />
     <TranslationEntry Key="ActionForm/cbxActionType[Play sound file]" Translation="Play sound file" />
     <TranslationEntry Key="ActionForm/cbxActionType[Scalar variable operation]" Translation="Scalar variable operation" />
     <TranslationEntry Key="ActionForm/cbxActionType[Send keypresses to active window]" Translation="Send keypresses to active window" />
@@ -111,6 +112,15 @@
     <TranslationEntry Key="ActionForm/cbxObsOpType[Stop recording]" Translation="Stop recording" />
     <TranslationEntry Key="ActionForm/cbxObsOpType[Stop replay buffer]" Translation="Stop replay buffer" />
     <TranslationEntry Key="ActionForm/cbxObsOpType[Stop streaming]" Translation="Stop streaming" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Start or Split]" Translation="Start run or split" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Start]" Translation="Start run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Split]" Translation="Split" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Undo Split]" Translation="Undo split" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Skip Split]" Translation="Skip split" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Reset]" Translation="Reset run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Pause]" Translation="Pause run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Resume]" Translation="Resume run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Custom payload]" Translation="Custom payload" />
     <TranslationEntry Key="ActionForm/cbxProcessLog" Translation="Process message as log line" />
     <TranslationEntry Key="ActionForm/cbxProcessWindowStyle[Hidden from view]" Translation="Hidden from view" />
     <TranslationEntry Key="ActionForm/cbxProcessWindowStyle[Maximized to fullscreen]" Translation="Maximized to fullscreen" />
@@ -256,6 +266,8 @@
     <TranslationEntry Key="ActionForm/lblObsSceneName" Translation="Scene name" />
     <TranslationEntry Key="ActionForm/lblObsSourceName" Translation="Source name" />
     <TranslationEntry Key="ActionForm/lblObsWebsocketInfo" Translation="If you are using OBS v27 or older, you will have to install the OBS WebSocket plugin to use OBS remote control features. There is a simple installer available at:" />
+    <TranslationEntry Key="ActionForm/lblLsOpType" Translation="Operation type" />
+    <TranslationEntry Key="ActionForm/lblLsCustPayload" Translation="Custom payload" />
     <TranslationEntry Key="ActionForm/lblProcessName" Translation="Process to launch" />
     <TranslationEntry Key="ActionForm/lblProcessParameters" Translation="Command line parameters" />
     <TranslationEntry Key="ActionForm/lblProcessWarning" Translation="Actions of this type may be potentially dangerous and cause damage if, for example, the trigger is fired with parameters that fall outside of the expected values. Please be aware of the risk." />
@@ -641,6 +653,15 @@
     <TranslationEntry Key="internal/Action/descobstogglereplay" Translation="start/stop OBS replay buffer (toggle)" />
     <TranslationEntry Key="internal/Action/descobstogglestream" Translation="start/stop streaming on OBS (toggle)" />
     <TranslationEntry Key="internal/Action/descobstogglerecordpause" Translation="resume/pause recording on OBS (toggle)" />
+    <TranslationEntry Key="internal/Action/desclsstartorsplit" Translation="Start run or split on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclsstart" Translation="Start run on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclssplit" Translation="Split on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclsundosplit" Translation="Undo split on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclsskipsplit" Translation="Skip split on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclsreset" Translation="Reset run on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclspause" Translation="Pause run on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclsresume" Translation="Resume run on LiveSplit" />
+    <TranslationEntry Key="internal/Action/desclscustompayload" Translation="Send custom payload to LiveSplit" />
     <TranslationEntry Key="internal/Action/descplaysound" Translation="play sound file ({0}) at volume ({1}) %" />
     <TranslationEntry Key="internal/Action/descprocessmessage" Translation="process message ({0}) as log line" />
     <TranslationEntry Key="internal/Action/descscalarnumeric" Translation="set scalar variable ({0}) value with numeric expression ({1})" />
@@ -713,6 +734,10 @@
     <TranslationEntry Key="internal/Action/obsconnectversionerror" Translation="Your version of OBS WebSocket is not currently supported." />
     <TranslationEntry Key="internal/Action/obsauthpassword" Translation="OBS WebSocket authentication required, you must provide a password" />
     <TranslationEntry Key="internal/Action/regexlistunset" Translation="All list variables matching ({0}) unset" />
+    <TranslationEntry Key="internal/Action/lsconnecterror" Translation="Error connecting to LiveSplit: {0}" />
+    <TranslationEntry Key="internal/Action/lsconnectok" Translation="LiveSplit connected successfully" />
+    <TranslationEntry Key="internal/Action/lscontrolerror" Translation="Can't execute LiveSplit control action due to error" />
+    <TranslationEntry Key="internal/Action/lscontrolexception" Translation="Can't execute LiveSplit control action due to exception: " />
     <TranslationEntry Key="internal/Action/regexscalarunset" Translation="All scalar variables matching ({0}) unset" />
     <TranslationEntry Key="internal/Action/regextableunset" Translation="All table variables matching ({0}) unset" />
     <TranslationEntry Key="internal/Action/scalarlistsplit" Translation="Scalar variable ({0}) split into list variable ({1}) with separator ({2})" />

--- a/Translations/default.triglations.xml
+++ b/Translations/default.triglations.xml
@@ -112,14 +112,14 @@
     <TranslationEntry Key="ActionForm/cbxObsOpType[Stop recording]" Translation="Stop recording" />
     <TranslationEntry Key="ActionForm/cbxObsOpType[Stop replay buffer]" Translation="Stop replay buffer" />
     <TranslationEntry Key="ActionForm/cbxObsOpType[Stop streaming]" Translation="Stop streaming" />
-    <TranslationEntry Key="ActionForm/cbxLsOpType[Start or Split]" Translation="Start run or split" />
-    <TranslationEntry Key="ActionForm/cbxLsOpType[Start]" Translation="Start run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Start run or split]" Translation="Start run or split" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Start run]" Translation="Start run" />
     <TranslationEntry Key="ActionForm/cbxLsOpType[Split]" Translation="Split" />
-    <TranslationEntry Key="ActionForm/cbxLsOpType[Undo Split]" Translation="Undo split" />
-    <TranslationEntry Key="ActionForm/cbxLsOpType[Skip Split]" Translation="Skip split" />
-    <TranslationEntry Key="ActionForm/cbxLsOpType[Reset]" Translation="Reset run" />
-    <TranslationEntry Key="ActionForm/cbxLsOpType[Pause]" Translation="Pause run" />
-    <TranslationEntry Key="ActionForm/cbxLsOpType[Resume]" Translation="Resume run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Undo split]" Translation="Undo split" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Skip split]" Translation="Skip split" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Reset run]" Translation="Reset run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Pause run]" Translation="Pause run" />
+    <TranslationEntry Key="ActionForm/cbxLsOpType[Resume run]" Translation="Resume run" />
     <TranslationEntry Key="ActionForm/cbxLsOpType[Custom payload]" Translation="Custom payload" />
     <TranslationEntry Key="ActionForm/cbxProcessLog" Translation="Process message as log line" />
     <TranslationEntry Key="ActionForm/cbxProcessWindowStyle[Hidden from view]" Translation="Hidden from view" />


### PR DESCRIPTION
This is a feature PR to add a new action which will interact with  [LiveSplit](https://livesplit.org/), a popular tool for time/segment tracking (primarily used for speedrunning).

Example use-cases for Triggernometry:
- Dungeon speedrun phase tracking. [Sample](<https://youtu.be/7p8Llx9nQV8>)
- Single-segment speedruns, allowing users to show runtime on streams without having to show OverlayPlugin overlays or Dalamud plugins.
- Jump-puzzle or other non-combat related speedruns. [Sample](<https://youtu.be/yUMcVjnZfSE>)

Current actions supported by this PR:
- Starting a new run
- Starting a new run, or splitting if the run is already started
- Split
- Undo split
- Skip split
- Reset run
- Pause run
- Resume run
- Custom payload, allowing users to run commands not explicitly covered in this PR. [Full list of commands](https://github.com/LiveSplit/LiveSplit/blob/1.8.25/LiveSplit/LiveSplit.Core/Server/CommandServer.cs#L143-L336)