### PR TITLE
Fix an RGB Component Conversion Bug of Text Aura Background Color

### DIFF
--- a/Source/Triggernometry/Scarborough/ScarboroughText.cs
+++ b/Source/Triggernometry/Scarborough/ScarboroughText.cs
@@ -135,9 +135,9 @@ namespace Scarborough
                     _BackgroundColor = value;
                     if (_BackgroundColor != System.Drawing.Color.Transparent)
                     {
-                        _bgColor.R = _BackgroundColor.R;
-                        _bgColor.G = _BackgroundColor.G;
-                        _bgColor.B = _BackgroundColor.B;
+                        _bgColor.R = _BackgroundColor.R / 255.0f;
+                        _bgColor.G = _BackgroundColor.G / 255.0f;
+                        _bgColor.B = _BackgroundColor.B / 255.0f;
                     }
                     else
                     {


### PR DESCRIPTION
Corrected the type mismatch between System.Drawing.Color (R/G/B: byte) and the custom Scarborough.Drawing.Color (R/G/B: 0.0f-1.0f) struct.

Original:
    `_bgColor.R = _BackgroundColor.R;`
Fixed:
    `_bgColor.R = _BackgroundColor.R / 255.0f;`

The original code would convert any input non-zero R/G/B value to maximum when displaying a text aura. _e.g._ background color `#0055FF` would be displayed as `#00FFFF`.

image example: https://discord.com/channels/374517624228544512/374555392119930882/1078119169544953864