### PR TITLE
Add new functions: "switch" and "roundir"

### DIFF
--- a/Source/Triggernometry/Context.cs
+++ b/Source/Triggernometry/Context.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
@@ -976,6 +976,26 @@ namespace Triggernometry
                                                 case 2:
                                                     val = funcval.Substring(Int32.Parse(args[0]), Int32.Parse(args[1]));
                                                     break;
+                                            }
+                                        }
+                                        break;
+                                    case "switch": // switch(index, [charcode])
+                                        if (argc != 1 && argc != 2)
+                                        {
+                                            throw new ArgumentException(I18n.Translate("internal/Context/switchargerror", "Switch function requires one or two arguments, {0} were given", argc));
+                                        }
+                                        else
+                                        {
+                                            char separator = argc == 2 ? (char)Int32.Parse(args[1]) : ',';
+                                            string[] strArray = funcval.Split(separator);
+                                            int index = Int32.Parse(args[0]);
+                                            if (index < 0 || index >= strArray.Length)
+                                            {
+                                                throw new ArgumentException(I18n.Translate("internal/Context/switchindexerror", "Switch function index {0} out of range 0-{1}", index, strArray.Length - 1));
+                                            }
+                                            else
+                                            {
+                                                val = strArray[index];
                                             }
                                         }
                                         break;

--- a/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
+++ b/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
@@ -35,9 +35,9 @@ namespace Triggernometry.CustomControls
         public static List<string> funcs = new List<string>()
         {
             // functions
-            "toupper", "tolower", "length", "dec2hex", "dec2hex2", "dec2hex4", "dec2hex8", "hex2float", "hex2double", "float2hex", "double2hex", "padleft(x, y)", "padright(x, y)",
-            "substring(x)", "substring(x, y)", "switch(x)", "switch(x, charcode)", "indexof(x)", "lastindexof(x)", "trim", "trim(x, ...)", "trimleft", "trimleft(x, ...)", "trimright", "trimright(x, ...)", 
-            "format(x, y)", "compare(x)", "compare(x, y)", "utctime(format)", "localtime(format)",
+            "toupper", "tolower", "length", "dec2hex", "dec2hex2", "dec2hex4", "dec2hex8", "hex2float", "hex2double", "float2hex", "double2hex", "padleft(x,y)", "padright(x,y)",
+            "substring(x)", "substring(x,y)", "switch(x)", "switch(x,charcode)", "indexof(x)", "lastindexof(x)", "trim", "trim(x,...)", "trimleft", "trimleft(x,...)", "trimright", "trimright(x,...)", 
+            "format(x,y)", "compare(x)", "compare(x,y)", "utctime(format)", "localtime(format)",
         };
 
         public static List<string> propstextaura = new List<string>()

--- a/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
+++ b/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
@@ -36,8 +36,8 @@ namespace Triggernometry.CustomControls
         {
             // functions
             "toupper", "tolower", "length", "dec2hex", "dec2hex2", "dec2hex4", "dec2hex8", "hex2float", "hex2double", "float2hex", "double2hex", "padleft(x, y)", "padright(x, y)",
-            "substring(x)", "substring(x, y)", "indexof(x)", "lastindexof(x)", "trim", "trim(x, ...)", "trimleft", "trimleft(x, ...)", "trimright", "trimright(x, ...)", "format(x, y)", "compare(x)", "compare(x, y)",
-            "utctime(format)", "localtime(format)",
+            "substring(x)", "substring(x, y)", "switch(x)", "switch(x, charcode)", "indexof(x)", "lastindexof(x)", "trim", "trim(x, ...)", "trimleft", "trimleft(x, ...)", "trimright", "trimright(x, ...)", 
+            "format(x, y)", "compare(x)", "compare(x, y)", "utctime(format)", "localtime(format)",
         };
 
         public static List<string> propstextaura = new List<string>()

--- a/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
+++ b/Source/Triggernometry/CustomControls/ExpressionTextBox.cs
@@ -20,9 +20,9 @@ namespace Triggernometry.CustomControls
         {
             // numeric
             "pi", "pi2", "pi05", "pi025", "pi0125", "pitorad", "piofrad", "phi", "major", "minor",
-            "abs(x)", "cos(x)", "cosh(x)", "arccos(x)", "cosec(x)", "sin(x)", "sinh(x)", "arcsin(x)", "sec(x)", "tan(x)", "tanh(x)", "arctan(x)", "arctan2(x, y)",
-            "cotan(x)", "distance(x1, y1, x2, y2)", "radtodeg(x)", "degtorad(x)", "max(...)", "min(...)", "random(x, y)", "sqrt(x)", "root(x, y)", "rem(x, y)", "mod(x, y)",
-            "pow(x, y)", "exp(x)", "log(x)", "log(x, y)", "round(x)", "round(x, y)", "floor(x)", "ceiling(x)", "sign(x)", "hex2dec(x)", "or(...)", "and(...)", "if(x,y,z)",
+            "abs(x)", "cos(x)", "cosh(x)", "arccos(x)", "cosec(x)", "sin(x)", "sinh(x)", "arcsin(x)", "sec(x)", "tan(x)", "tanh(x)", "arctan(x)", "arctan2(x,y)",
+            "cotan(x)", "distance(x1,y1,x2,y2)", "radtodeg(x)", "degtorad(x)", "roundir(θ,n)", "roundir(x,y,n)", "max(...)", "min(...)", "random(x,y)", "sqrt(x)", "root(x,y)", "rem(x,y)", "mod(x,y)",
+            "pow(x,y)", "exp(x)", "log(x)", "log(x,y)", "round(x)", "round(x,y)", "truncate(x)", "floor(x)", "ceiling(x)", "sign(x)", "hex2dec(x)", "or(...)", "and(...)", "if(x,y,z)",
             // expressions
             "numeric", "string", "var", "evar", "lvar", "elvar", "tvar", "tvarcl", "tvarrl", "etvar", "func", "pvar", "epvar", "plvar", "eplvar", "ptvar", "ptvarcl", "ptvarrl", "eptvar",
             // special variables

--- a/Source/Triggernometry/MathParser.cs
+++ b/Source/Triggernometry/MathParser.cs
@@ -282,8 +282,8 @@ namespace Triggernometry
 
                     // 'segments' can be positive / negative. 
                     // Positive means north is a segment point, while negative means north is the midpoint of two segment points.
-                    // e.g. roundir(radius, 4): corresponds to cardinal directions (N = 0, W = 1, S = 2, E = 3);
-                    // roundir(radius, -4): corresponds to intercardinal directions (NW = 0, SW = 1, SE = 2, NE = 3)
+                    // e.g. roundir(rad, 4): corresponds to cardinal directions (N = 0, W = 1, S = 2, E = 3);
+                    // roundir(rad, -4): corresponds to intercardinal directions (NW = 0, SW = 1, SE = 2, NE = 3)
                     if (segments > 0)
                     {
                         return Math.Round((rad + Math.PI) / (2 * Math.PI) * segments) % segments;

--- a/Source/Triggernometry/MathParser.cs
+++ b/Source/Triggernometry/MathParser.cs
@@ -290,6 +290,7 @@ namespace Triggernometry
                     }
                     else if (segments < 0)
                     {
+                        segments = -segments;
                         return Math.Round((rad + Math.PI) / (2 * Math.PI) * segments - 0.5) % segments;
                     }
                     else

--- a/Source/Triggernometry/MathParser.cs
+++ b/Source/Triggernometry/MathParser.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright (C) 2012-2016 Mathos Project,
  * All rights reserved.
  * 
@@ -242,7 +242,6 @@ namespace Triggernometry
                     return min;
                 });
 
-                //LocalFunctions.Add("round", x => Math.Round(x[0]));
                 LocalFunctions.Add("truncate", x => x[0] < 0 ? -Math.Floor(-x[0]) : Math.Floor(x[0]));
                 LocalFunctions.Add("floor", x => Math.Floor(x[0]));
                 LocalFunctions.Add("ceiling", x => Math.Ceiling(x[0]));
@@ -255,8 +254,51 @@ namespace Triggernometry
                 LocalStringFunctions.Add("hex2dec", x => Hex2DecFunction(x));
                 LocalStringFunctions.Add("hex2float", x => Hex2FloatFunction(x));
                 LocalStringFunctions.Add("hex2double", x => Hex2DoubleFunction(x));
-
                 LocalStringFunctions.Add("X8float", x => Hex2FloatFunction(x));
+
+                LocalFunctions.Add("roundir", delegate (double[] input)
+                {
+                    // Matches the given direction (in radian or as dx/dy offsets) 
+                    // to the direction in a circle divided into 'n' segments, 
+                    // and returns the index of the direction.
+                    // indexes: 0, 1, 2, ..., n-1, from north CCW.
+                    double rad;
+                    double segments;
+                    switch (input.Length)
+                    {
+                        // roundir(rad, segments) or roundir(dx, dy, segments)
+                        case 2:
+                            // normalize radian to [-π, π)
+                            rad = ((input[0] + Math.PI) % (2 * Math.PI) + 2 * Math.PI) % (2 * Math.PI) - Math.PI;
+                            segments = input[1];
+                            break;
+                        case 3:
+                            rad = Math.Atan2(input[0], input[1]);
+                            segments = input[2];
+                            break;
+                        default:
+                            return 0;
+                    }
+
+                    // 'segments' can be positive / negative. 
+                    // Positive means north is a segment point, while negative means north is the midpoint of two segment points.
+                    // e.g. roundir(radius, 4): corresponds to cardinal directions (N = 0, W = 1, S = 2, E = 3);
+                    // roundir(radius, -4): corresponds to intercardinal directions (NW = 0, SW = 1, SE = 2, NE = 3)
+                    if (segments > 0)
+                    {
+                        return Math.Round((rad + Math.PI) / (2 * Math.PI) * segments) % segments;
+                    }
+                    else if (segments < 0)
+                    {
+                        return Math.Round((rad + Math.PI) / (2 * Math.PI) * segments - 0.5) % segments;
+                    }
+                    else
+                    {
+                        return 0; // false
+                    }
+                });
+
+
             }
 
             if (loadPreDefinedVariables)

--- a/Translations/default.triglations.xml
+++ b/Translations/default.triglations.xml
@@ -837,6 +837,8 @@
     <TranslationEntry Key="internal/Context/padleftargerror" Translation="Padleft function requires two arguments, {0} were given" />
     <TranslationEntry Key="internal/Context/padrightargerror" Translation="Padright function requires two arguments, {0} were given" />
     <TranslationEntry Key="internal/Context/substringargerror" Translation="Substring function requires one or two arguments, {0} were given" />
+    <TranslationEntry Key="internal/Context/switchargerror" Translation="Switch function requires one or two arguments, {0} were given" />
+    <TranslationEntry Key="internal/Context/switchindexerror" Translation="Switch function index {0} out of range 0-{1}" />
     <TranslationEntry Key="internal/ExportForm/exception" Translation="Exception" />
     <TranslationEntry Key="internal/ExpressionTextBox/numeric1" Translation="This field supports numeric expressions; references to named regular expression groups will be expanded, after which the result will be evaluated as a mathematic expression." />
     <TranslationEntry Key="internal/ExpressionTextBox/numeric2" Translation="The color of the field will also change depending on whether the numeric expression appears to be valid (green) or not (red)." />

--- a/Translations/zh-CN.triglations.xml
+++ b/Translations/zh-CN.triglations.xml
@@ -800,6 +800,8 @@
         <TranslationEntry Key="internal/Context/padleftargerror" Translation="Padleft 函数要求 2 个参数，但却传入了 {0} 个" />
         <TranslationEntry Key="internal/Context/padrightargerror" Translation="Padright 函数要求 2 个参数，但却传入了 {0} 个" />
         <TranslationEntry Key="internal/Context/substringargerror" Translation="Substring 函数要求 1 或 2 个参数，但却传入了 {0} 个" />
+        <TranslationEntry Key="internal/Context/switchargerror" Translation="Switch 函数要求 1 或 2 个参数，但却传入了 {0} 个" />
+        <TranslationEntry Key="internal/Context/switchindexerror" Translation="Switch 函数索引 {0} 超出字符串序列长度范围 0-{1}" />
         <TranslationEntry Key="internal/ExportForm/exception" Translation="异常" />
         <TranslationEntry Key="internal/ExpressionTextBox/numeric1" Translation="该字段支持数值表达式; 将扩展对命名正则表达式组的引用，之后将结果作为数学表达式进行求值。" />
         <TranslationEntry Key="internal/ExpressionTextBox/numeric2" Translation="字段的颜色也将根据数字表达式是否有效(绿色)或无效(红色)而改变。" />

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,8 @@ Several frequently-used words could now be replaced with their abbrevations:
 · add slice supports for table.h/vjoin()  
 · ${_me}  
 · table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)  
-· distance=>d(x1, y1, x2, y2), angle/θ(x1, y1, x2, y2)  
+· distance=>d(x1, y1, ..., x2, y2, ...) accepts 2n args and returns the n-th dimensional distance
+· angle/θ(x1, y1, x2, y2)
 · projecth(x1, y1, θ1, x2, y2), projectd(x1, y1, θ1, x2, y2) (could be negative), relangle/relθ(x1, y1, θ1, x2, y2)  
 · func:pick() respects negative arguments   
 · func:repeat(times, joiner = ""):str  for len(str) > 1.  

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,14 @@ https://github.com/paissaheavyindustries/Triggernometry
 ### Fixed https://github.com/paissaheavyindustries/Triggernometry/issues/92)https://github.com/paissaheavyindustries/Triggernometry/issues/92:  
 The original regex for string function could not parse `func:length:3*(1+2)` correctly, which considers `length:3*` as the function name and `1+2` as the argument.  
 The regex was editted to solve this issue; it could now also match the whole expression in one step instead of parsing the `funcval` by searching the index of `:` later.  
+### Fixed the MathParser bugs about parsing minus signs: 
+The original code only examines the previous character to determine if a +/- is a positive/negative sign or a plus/minus sign.  
+Expressions like `func(arg, -arg)` or `1 - -1` were wrongly parsed.  
+Also, `${numeric:-(-1)}` was parsed into `-1`.
+Changed the parser logic about plus/minus signs.  
+**...**
+· Fixed a condition check typo when parsing parenthesis.  
+"char.IsDigit(...) || char.IsLetter(...)" was typed as "char.IsDigit(...) || char.IsDigit(...)", which ignored the letter check when adding "*" before "(".
 ### Fixed a bug in the method `VariableList.Insert`:
 The original code inserted `null` as placeholders when the given index is longer than the length of the list (should use new `Variable` instead).  
 The parser could not get these null values in expressions; it also caused the list could not be double-clicked in the variable viewer.   
@@ -111,12 +119,13 @@ Several frequently-used words could now be replaced with their abbrevations:
 · add slice supports for table.h/vjoin()  
 · ${_me}  
 · table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)  
-· distance=>d(x1, y1, ..., x2, y2, ...) accepts 2n args and returns the n-th dimensional distance  
-· projecth(x1, y1, θ1, x2, y2), projectd(x1, y1, θ1, x2, y2) (could be negative)  
-· angle/θ(x1, y1, x2, y2)  relangle/relθ(x1, y1, θ1, x2, y2)  
+· ✓ distance=>d(x1, y1, ..., x2, y2, ...) accepts 2n args and returns the n-th dimensional distance  
+· ✓ projh(x1, y1, θ1, x2, y2), projd(x1, y1, θ1, x2, y2)
+· ✓ angle/θ(x1, y1, x2, y2)  relangle/relθ(x1, y1, θ1, x2, y2)  
 · func:pick() respects negative arguments   
 · func:repeat(times, joiner = ""):str  for len(str) > 1.  
 · Table action: generate from string (expr = colJoiner + rowJoiner + str)  
 · Table action: seperate the expr with its first character then insert after the given row / col index  
 · Sort the current list actions order  
 · check the definition for "" as an arg  
+· `${_ffxiventity[name].jobcn1}` `${_ffxiventity[name].jobcn2}` `${_ffxiventity[name].jobjp}`

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ The original code only examines the previous character to determine if a +/- is 
 Expressions like `func(arg, -arg)` or `1 - -1` were wrongly parsed.  
 Also, `${numeric:-(-1)}` was parsed into `-1`.
 Changed the parser logic about plus/minus signs.  
-**...**
-· Fixed a condition check typo when parsing parenthesis.  
+**...**  
+### Fixed a condition check typo when parsing parenthesis.  
 "char.IsDigit(...) || char.IsLetter(...)" was typed as "char.IsDigit(...) || char.IsDigit(...)", which ignored the letter check when adding "*" before "(".
 ### Fixed a bug in the method `VariableList.Insert`:
 The original code inserted `null` as placeholders when the given index is longer than the length of the list (should use new `Variable` instead).  
@@ -128,4 +128,4 @@ Several frequently-used words could now be replaced with their abbrevations:
 · Table action: seperate the expr with its first character then insert after the given row / col index  
 · Sort the current list actions order  
 · check the definition for "" as an arg  
-· `${_ffxiventity[name].jobcn1}` `${_ffxiventity[name].jobcn2}` `${_ffxiventity[name].jobjp}`
+· `${_ffxiventity[name].jobcn1}` `${_ffxiventity[name].jobcn2}` `${_ffxiventity[name].jobjp}`  

--- a/readme.md
+++ b/readme.md
@@ -104,16 +104,16 @@ Several frequently-used words could now be replaced with their abbrevations:
 `${func:indexof(...):str}`, `${func:laseindexof(...):str}` could be short as `${func:i(...):str}`, `${func:li(...):str}`;  
 
 ## To-do List
-· I18n (added part)
-· Previous translations
+· I18n (added part)  
+· Previous translations  
 · rewrite list.sum() / list.join() with the new SplitArgs function  
 · deal with out-of-range indices in str.slice()  
 · add slice supports for table.h/vjoin()  
 · ${_me}  
-· table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)
-· func:pick() respects negative arguments  
-· func:repeat(times, joiner = ""):str  for len(str) > 1.
-· Table action: generate from string (expr = colJoiner + rowJoiner + str)
-· Table action: seperate the expr with its first character then insert after the given row / col index
-· Sort the current list actions order
-· check the definition for "" as an arg
+· table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)  
+· func:pick() respects negative arguments   
+· func:repeat(times, joiner = ""):str  for len(str) > 1.  
+· Table action: generate from string (expr = colJoiner + rowJoiner + str)  
+· Table action: seperate the expr with its first character then insert after the given row / col index  
+· Sort the current list actions order  
+· check the definition for "" as an arg  

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,113 @@
-## Documentation
+This document is a summary for my edited parts.
 
-Triggernometry has a Wiki, containing useful information and documentation:
+Check the main repo for Triggernometry documentations:
+https://github.com/paissaheavyindustries/Triggernometry
 
-https://github.com/paissaheavyindustries/Triggernometry/wiki
+# What's New
+## Bug Fixes
+### Fixed https://github.com/paissaheavyindustries/Triggernometry/issues/92)https://github.com/paissaheavyindustries/Triggernometry/issues/92:  
+The original regex for string function could not parse `func:length:3*(1+2)` correctly, which considers `length:3*` as the function name and `1+2` as the argument.  
+The regex was editted to solve this issue; it could now also match the whole expression in one step instead of parsing the `funcval` by searching the index of `:` later.  
+### Fixed a bug in the method `VariableList.Insert`:
+The original code inserted `null` as placeholders when the given index is longer than the length of the list (should use new `Variable` instead).  
+The parser could not get these null values in expressions; it also caused the list could not be double-clicked in the variable viewer.   
+### Fixed a bug in the method `VariableList.Set`:
+The original code inserted 1 less empty `Variable` into the list as placeholders.    
+It caused the program trying to set the value at the given `index` into the list with the length `index - 1` and failed.  
+### Fixed a bug in the function `SplitArguments`:  
+The original function had complex checks for single and double quotes, which might result in incorrect `args` list when encountering unmatched quote pairs or consecutive commas.    
+The editted code now utilizes regular expressions to accurately extract all parameters located between the string's beginning, end, and commas.  
+Additionally, trimming has been added for parameters without quotes.  
+e.g. (1,2,  3  ,"  4  ",   "5"  , "'", ', ', ) is now parsed into a list with the arguments:   
+`1` `2` `3` `  4  ` `5` `'` `, ` `​`.  
 
-To get answers to some commonly asked questions, and to get more information on how to use Triggernometry, you can find more information in the Triggernometry FAQ and examples section:
+## Added new methods for list variables:  
+The following part uses `list = [1,2,3,4,5,6]` as an example.  
+### · `listname.count(str)`  
+Counts the repeated times of a given string in the list.    
+e.g. `lvar:list.count(2)` = `1`, `lvar:list.count(10)` = `0`  
+### · `joinslice(joiner = ",", start, end, step)`
+Also as `join(...)`  
+All parameters could be omitted.    
+The final 3 arguments works as the list slices in Python which accepts negative indices as reversed indices;    
+however the positive indices counts from 1 instead of 0 to be consistent with the current features.  
+e.g. `lvar:list.joinslice` = `1,2,3,4,5,6`, `lvar:list.joinslice(" ",2,5)` = `2 3 4`, `lvar:list.joinslice(,-1,1,-1)` = `6,5,4,3,2`.  
+### · `sumslice(start, end, step)`, also as `sum(...)`
+Similar to the previous method. Adding all the values which could be parsed as `double` in the given slice and returns the sum.  
+e.g. `lvar:list.sumslice` = `21`, `lvar:list.sumslice(,4)` = 6`, `lvar:list.joinslice(,,2)` = `15`.  
 
-https://github.com/paissaheavyindustries/Triggernometry/wiki/Triggernometry-FAQ-and-examples
+## Added new methods for table variables:  
+The following part uses this `table` as an example:
+```
+11, 12, 13, 14
+21, 22, 23, 24
+31, 32, 33, 34
+```
+### · `join(colJoiner = ",")`
+Connects the values of all cells in the table into a string.  
+The column joiner could be given as an argument and the row joiner is fixed as "\n".  
+### · `hjoinslice(rowIndex, joiner = ",", start, end, step)`  
+### · `vjoinslice(colIndex, joiner = ",", start, end, step)`  
+Also as `hjoin(...)` and `vjoin(...)`  
+Similar to list.joinslice(joiner = ",", start, end, step), which horizontally / vertically extracts the row / column with the given index and joins the corresponding slice to a string.  
+e.g. `list.vjoin(2)` = `12,22,32`, `list.hjoin(3," ",2,,2)` = `32 34`  
+### · `hlookup(targetValue, rowIndex = 1, direction = 1)`  
+### · `vlookup(targetValue, colIndex = 1, direction = 1)`    
+Also as `hl(...)` and `vl(...)`  
+Look up the given value horizontally / vertically in the given row / col index. Returns the first found col / row index, or `0` when not found.  
+The third parameter `direction` is set to 1 as default. A positive integer means searching from the beginning, and non-positive integer means searching from the end.  
+e.g. `list.vlookup(21)` = `2`, `list.hlookup(00)` = `0`, `list.hlookup(32, 3, -1)` = `2` (`-1` works the same as `1` in this case since there is only one 32.)  
 
-## Discord
+## Added / Updated functions for string variables:  
+### · `func:parsedmg:hexstr`  
+Parse the given hexstr damage value in the `0x15` / `0x16` ACT loglines to the corresponding decimal value.  
+Rule: padleft the hexstr with `0` to 8 digits like `XXXXYYZZ`, then convert `ZZXXXX` to decimal.  
+### · `func:slice(start, end, step):str`  
+Works the same as the string slice in Python. Indices starts from 0 and negative indices means counting from the end.  
+e.g. `func:slice(-3):01234` = `234`, `func:slice(1,4):01234` = `123`, `func:slice(,,-1):01234` = `43210`, `func:slice(3,,-2):01234` = `31`  
+### · `func:pick(index, separator = ","):str`
+### · `func:pick(index, separator charcode):str`    
+Separates the given string by the given separator (default as ","). Returns the separated index of string counting from 0. Also supports negative values.  
+Separator could be given as a charcode, but `0`-`9` would be considered as a number character (since nobody would use those control characters with charcode 0-9 in Triggernometry).  
+e.g. `func:pick(3):north,west,south,east` = `east`, `func:pick(-1,"--"):1--22--3--44--5` = `5`, `func:pick(1,48):10220304405` = `22` (charcode of `0` is 48)  
+### · Added string arguments support to `padleft`, `padright`, `trim`, `trimleft`, `trimright`  
+Similar to the `pick` function above, these functions now also accepts character arguments given as the character itself instead of only by its charcode.    
+Get rid of those 5-digit charcodes of CJK-region characters. (even full-width spaces)    
 
-Triggernometry also has a publicly available Discord server for announcements, suggestions, and questions related to the plugin. Feel free to join at:
+## Added numeric function: 
+### · `roundir(θ, n)` or `roundir(dx, dy, n)`
+Matches the given direction (in radian or as `dx`/`dy` offsets) to the direction in a circle divided into `|n|` segments, and returns the index of the direction.   
+Could combine with `func:pick(index)` and easily output any direction as a string from a radian / coordinate with no more complicated `arctan2` and `mod` calculations.  
+The sign of `n` indicates 2 division modes: north is the segment point or the border of 2 segments, as shown below.  
+e.g. `roundir(-1.57,4)` = `1` (West), `roundir(8,-6,-4)` = `3` (NE)
+![image](https://github.com/paissaheavyindustries/Triggernometry/assets/85232361/b7ab1f13-c5ba-4609-b588-b066d5d9d4e1)
 
-https://discord.gg/6f9MY55
+## Added `generate` action for list actions:  
+Generates a list variable using the first index of the expression as the separator, and the remained part as the given string.    
+Easily generates a list directly from a given string in a single action.  
+Could also generate a list from the slice of another list or even a row/column of a table in a single action, if combined with `list.join`, `table.hjoin`, `table.vjoin`.  
+
+## Added supports for negative indices:  
+Supports for negative indices are added to those original features :  
+· Peeking values in lvar and tvar, e.g. `${lvar:list[-2]}` gives the second last element. The original keyword `last` is also redirected to `-1`.  
+· tvarrl and tvarcl, e.g. `${tvarrl:table[title][-2]}` gives the second last element in the selected row. Also, `${tvarrl:table[title][0]}` looks up the row index of `title`.  
+· Insert / Set action of list / table variable actions.  
+· The `start` argument in `func:substring(start, ...)`.  
+The changes have no conflict with the original version since negative indices had no definations.  
+
+## Abbrevations for improving user experience：  
+Several frequently-used words could now be replaced with their abbrevations:  
+`${numeric:...}`, `${string:...}`, `${func:...}` could be short as `${n:...}`, `${s:...}`, `${f:...}`;  
+`${_ffxiventity[...].prop}`, `${_ffxivparty[...].prop}` could be short as `${_entity[...].prop}`, `${_party[...].prop}`;  
+`${_ffxivplayer}`, `${_ffxiventity[${_ffxivplayer}].prop}` could be short as `${_me}`, `${_me.prop}`;  
+`${lvar:list.indexof(...)}`, `${lvar:list.lastindexof(...)}` could be short as `${lvar:list.i(...)}`, `${lvar:list.li(...)}`;  
+`${func:indexof(...):str}`, `${func:laseindexof(...):str}` could be short as `${func:i(...):str}`, `${func:li(...):str}`;  
+
+## To-do List
+· I18n  
+· rewrite list.sum() / list.join() with the new SplitArgs function  
+· deal with out-of-range indices in str.slice()  
+· add slice supports for table.h/vjoin()  
+· ${_me}  
+· table.join() takes row joiner argument  
+· func:pick() respects negative arguments  

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,8 @@ Several frequently-used words could now be replaced with their abbrevations:
 · add slice supports for table.h/vjoin()  
 · ${_me}  
 · table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)  
+· distance=>d(x1, y1, x2, y2), angle/θ(x1, y1, x2, y2)
+· projecth(x1, y1, θ1, x2, y2), projectd(x1, y1, θ1, x2, y2) (could be negative), relangle/relθ(x1, y1, θ1, x2, y2)
 · func:pick() respects negative arguments   
 · func:repeat(times, joiner = ""):str  for len(str) > 1.  
 · Table action: generate from string (expr = colJoiner + rowJoiner + str)  

--- a/readme.md
+++ b/readme.md
@@ -111,8 +111,8 @@ Several frequently-used words could now be replaced with their abbrevations:
 · add slice supports for table.h/vjoin()  
 · ${_me}  
 · table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)  
-· distance=>d(x1, y1, x2, y2), angle/θ(x1, y1, x2, y2)
-· projecth(x1, y1, θ1, x2, y2), projectd(x1, y1, θ1, x2, y2) (could be negative), relangle/relθ(x1, y1, θ1, x2, y2)
+· distance=>d(x1, y1, x2, y2), angle/θ(x1, y1, x2, y2)  
+· projecth(x1, y1, θ1, x2, y2), projectd(x1, y1, θ1, x2, y2) (could be negative), relangle/relθ(x1, y1, θ1, x2, y2)  
 · func:pick() respects negative arguments   
 · func:repeat(times, joiner = ""):str  for len(str) > 1.  
 · Table action: generate from string (expr = colJoiner + rowJoiner + str)  

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ however the positive indices counts from 1 instead of 0 to be consistent with th
 e.g. `lvar:list.joinslice` = `1,2,3,4,5,6`, `lvar:list.joinslice(" ",2,5)` = `2 3 4`, `lvar:list.joinslice(,-1,1,-1)` = `6,5,4,3,2`.  
 ### · `sumslice(start, end, step)`, also as `sum(...)`
 Similar to the previous method. Adding all the values which could be parsed as `double` in the given slice and returns the sum.  
-e.g. `lvar:list.sumslice` = `21`, `lvar:list.sumslice(,4)` = 6`, `lvar:list.joinslice(,,2)` = `15`.  
+e.g. `lvar:list.sumslice` = `21`, `lvar:list.sumslice(,4)` = `6`, `lvar:list.joinslice(,,2)` = `15`.  
 
 ## Added new methods for table variables:  
 The following part uses this `table` as an example:
@@ -104,10 +104,16 @@ Several frequently-used words could now be replaced with their abbrevations:
 `${func:indexof(...):str}`, `${func:laseindexof(...):str}` could be short as `${func:i(...):str}`, `${func:li(...):str}`;  
 
 ## To-do List
-· I18n  
+· I18n (added part)
+· Previous translations
 · rewrite list.sum() / list.join() with the new SplitArgs function  
 · deal with out-of-range indices in str.slice()  
 · add slice supports for table.h/vjoin()  
 · ${_me}  
-· table.join() takes row joiner argument  
+· table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)
 · func:pick() respects negative arguments  
+· func:repeat(times, joiner = ""):str  for len(str) > 1.
+· Table action: generate from string (expr = colJoiner + rowJoiner + str)
+· Table action: seperate the expr with its first character then insert after the given row / col index
+· Sort the current list actions order
+· check the definition for "" as an arg

--- a/readme.md
+++ b/readme.md
@@ -111,9 +111,9 @@ Several frequently-used words could now be replaced with their abbrevations:
 · add slice supports for table.h/vjoin()  
 · ${_me}  
 · table.join(colJoiner, rowJoiner, colstart, colend, colstep, rowstart, rowend, rowstep)  
-· distance=>d(x1, y1, ..., x2, y2, ...) accepts 2n args and returns the n-th dimensional distance
-· angle/θ(x1, y1, x2, y2)
-· projecth(x1, y1, θ1, x2, y2), projectd(x1, y1, θ1, x2, y2) (could be negative), relangle/relθ(x1, y1, θ1, x2, y2)  
+· distance=>d(x1, y1, ..., x2, y2, ...) accepts 2n args and returns the n-th dimensional distance  
+· projecth(x1, y1, θ1, x2, y2), projectd(x1, y1, θ1, x2, y2) (could be negative)  
+· angle/θ(x1, y1, x2, y2)  relangle/relθ(x1, y1, θ1, x2, y2)  
 · func:pick() respects negative arguments   
 · func:repeat(times, joiner = ""):str  for len(str) > 1.  
 · Table action: generate from string (expr = colJoiner + rowJoiner + str)  


### PR DESCRIPTION
· Add `switch` function for string: `switch(index, [charcode])`
`${func:switch(2):north,west,south,east} = south`
`${func:switch(2, 48): 1022033304444} = 333` (charcode of "0" is 48)

· Add `roundir` function: `roundir(θ, n)` or `roundir(dx, dy, n)`
Matches the given direction (in radian or as `dx`/`dy` offsets) to the direction in a circle divided into `|n|` segments, and returns the index of the direction. 
The sign of `n` indicates 2 division modes: north is the segment point or the border of 2 segments.
`roundir(-1.57,4) = 1`
`roundir(8,-6,-4) = 3`
![image](https://github.com/paissaheavyindustries/Triggernometry/assets/85232361/b7ab1f13-c5ba-4609-b588-b066d5d9d4e1)


· Considering that Triggernometry could not parse function parameters with a minus sign after a space like `function(1, -1)` correctly, the spaces before function parameters in autofill are deleted, like `roundir(θ,n)`.